### PR TITLE
Add uninstall command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rust:
   - stable
   - beta
   - nightly
+script:
+  - cargo build --verbose
+  - ./tests/*.sh
 matrix:
   allow_failures:
     - rust: nightly

--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ List all installed versions:
 ```bash
 $ avm ls
 ```
+
+Uninstall a version:
+
+```bash
+$ avm uninstall 4.1.2
+```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ pub enum CmdOption {
     Use,
     Ls,
     Help,
+    Uninstall,
     Unknown
 }
 
@@ -16,6 +17,8 @@ pub fn help() {
     logger::stdout(format!("avm use <version>\n"));
     logger::stdout(format!("List all installed versions:"));
     logger::stdout(format!("avm ls\n"));
+    logger::stdout(format!("Uninstall a version:"));
+    logger::stdout(format!("avm uninstall <version>\n"));
     logger::stdout(format!("Print this help menu:"));
     logger::stdout(format!("avm help"));
 }
@@ -41,6 +44,9 @@ pub fn process_arguments(args: &Vec<String>) -> Command {
     }
     else if command == "help" {
         Command{option: CmdOption::Help, args: vec!()}
+    }
+    else if command == "uninstall" {
+        Command{option: CmdOption::Uninstall, args: vec!(args[1].clone()) }
     }
     else {
         Command { option: CmdOption::Unknown, args: vec!() }

--- a/src/ls.rs
+++ b/src/ls.rs
@@ -25,7 +25,7 @@ pub fn current_version() -> Option<String> {
         Ok(s) => s,
         _ => return None
     };
-    let re = Regex::new(r"\d\.\d\.\d").unwrap();
+    let re = Regex::new(r"\d+\.\d+\.\d+").unwrap();
     let path_str = path.as_os_str().to_str()
         .unwrap()
         .into();

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,22 @@ fn list_versions() {
     }
 }
 
+fn uninstall(version: String) {
+    if setup::has_version(&version) {
+        match setup::remove_version(&version) {
+            Ok(_) => logger::stdout(format!("Successfully removed version {}", version)),
+            Err(err) => {
+                logger::stderr(format!("Failed to remove version {}", version));
+                logger::stderr(format!("{:?}", err));
+            }
+        }
+    }
+    else {
+        logger::stderr(format!("Version {} is not installed", version));
+        std::process::exit(1)
+    }
+}
+
 fn main() {
     let args: Vec<String> = env::args()
         .skip(1)
@@ -122,6 +138,10 @@ fn main() {
         },
         cli::CmdOption::Ls => {
             list_versions();
+        },
+        cli::CmdOption::Uninstall => {
+            let version = cmd_args.args.first().unwrap().clone();
+            uninstall(version);
         },
         cli::CmdOption::Help => {
             cli::help();

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,32 +61,32 @@ fn install(version: String) {
 }
 
 fn use_version(version: String) {
-   if setup::has_version(&version) {
-       for executable in vec!["node", "npm"] {
-           match symlink::remove_symlink(&executable.to_string()) {
-               Err(err) => {
-                   if err.kind() != std::io::ErrorKind::NotFound {
-                       logger::stderr(format!("Failed to remove symlink {}", executable));
-                       logger::stderr(format!("{:?}", err));
-                       std::process::exit(1)
-                   }
-               },
-               _ => { }
-           };
+    if setup::has_version(&version) {
+        for executable in vec!["node", "npm"] {
+            match symlink::remove_symlink(&executable.to_string()) {
+                Err(err) => {
+                    if err.kind() != std::io::ErrorKind::NotFound {
+                        logger::stderr(format!("Failed to remove symlink {}", executable));
+                        logger::stderr(format!("{:?}", err));
+                        std::process::exit(1)
+                    }
+                },
+                _ => { }
+            };
 
-           match symlink::symlink_to_version(&version, executable.to_string()) {
-               Ok(_) => logger::stdout(format!("Now using {} {}", executable, version)),
-               Err(err) => {
-                   logger::stderr(format!("Failed to set symlink for {}", executable));
-                   logger::stderr(format!("{:?}", err));
-                   std::process::exit(1)
-               }
-           };
-       }
-   } else {
-       logger::stdout(format!("Version {} not installed", version));
-       std::process::exit(1)
-   }
+            match symlink::symlink_to_version(&version, executable.to_string()) {
+                Ok(_) => logger::stdout(format!("Now using {} {}", executable, version)),
+                Err(err) => {
+                    logger::stderr(format!("Failed to set symlink for {}", executable));
+                    logger::stderr(format!("{:?}", err));
+                    std::process::exit(1)
+                }
+            };
+        }
+    } else {
+        logger::stdout(format!("Version {} not installed", version));
+        std::process::exit(1)
+    }
 }
 
 fn list_versions() {
@@ -106,6 +106,22 @@ fn list_versions() {
 
 fn uninstall(version: String) {
     if setup::has_version(&version) {
+
+        if symlink::points_to_version(&version) {
+            for executable in vec!["node", "npm"] {
+                match symlink::remove_symlink(&executable.to_string()) {
+                    Err(err) => {
+                        if err.kind() != std::io::ErrorKind::NotFound {
+                            logger::stderr(format!("Failed to remove symlink {}", executable));
+                            logger::stderr(format!("{:?}", err));
+                            std::process::exit(1)
+                        }
+                    },
+                    _ => { }
+                }
+            }
+        }
+
         match setup::remove_version(&version) {
             Ok(_) => logger::stdout(format!("Successfully removed version {}", version)),
             Err(err) => {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,6 +3,14 @@ use std::fs;
 use std::env;
 use std::io::Error;
 
+fn version_path(version: &String) -> String {
+    Path::new(&avm_directory()).join(version)
+        .as_path()
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
 pub fn avm_directory() -> String {
     let home_directory = env::home_dir().unwrap();
     let avm = home_directory.join(".avm");
@@ -27,8 +35,7 @@ pub fn prepare() -> Result<String, Error> {
 }
 
 pub fn create_version_directory(version: &String) -> Result<String, Error> {
-    let path = Path::new(&avm_directory()).join(version)
-        .as_path().to_str().unwrap().to_string();
+    let path = version_path(&version);
     match fs::create_dir(&path) {
         Ok(_) => Ok(path.clone()),
         Err(err) => Err(err)
@@ -36,11 +43,14 @@ pub fn create_version_directory(version: &String) -> Result<String, Error> {
 }
 
 pub fn has_version(version_str: &String) -> bool {
-    let path = Path::new(&avm_directory()).join(version_str)
-        .as_path().to_str().unwrap().to_string();
+    let path = version_path(&version_str);
     match fs::metadata(path) {
         Ok(metadata) => metadata.is_dir(),
         Err(_) => false
     }
 }
 
+pub fn remove_version(version_str: &String) -> Result<(), Error> {
+    let path = version_path(&version_str);
+    fs::remove_dir_all(path)
+}

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -2,6 +2,16 @@ use setup;
 use std::path::Path;
 use std::os::unix::fs;
 use std::io::Error;
+use ls;
+
+pub fn points_to_version(version: &String) -> bool {
+    let current_version = match ls::current_version() {
+        Some(v) => v,
+        None => return false
+    };
+
+    &current_version == version
+}
 
 pub fn remove_symlink(executable: &String) -> Result<(), Error> {
     use std::fs;

--- a/tests/uninstall_version.sh
+++ b/tests/uninstall_version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cargo run install 0.12.0
+cargo run use 0.12.0
+cargo run uninstall 0.12.0
+result=$(readlink ~/.avm/node)
+if [ $? -eq 1 ]
+then
+  echo "Symlink node removed"
+else
+  echo "Symlink node still exists"
+  exit 1
+fi
+
+result=$(readlink ~/.avm/npm)
+if [ $? -eq 1 ]
+then
+  echo "Symlink npm removed"
+else
+  echo "Symlink npm still exists"
+  exit 1
+fi


### PR DESCRIPTION
This PR (for #7)  adds a new command:

``` bash
$ avm uninstall 4.1.2
```

This uninstalls a node.js version from the machine.
Also now there's a `tests/` folder containing integration tests. Right now, there's an integration test for the uninstall command
