### PR TITLE
ls omits directories which do not have version number as name

### DIFF
--- a/src/ls.rs
+++ b/src/ls.rs
@@ -19,6 +19,11 @@ fn directory_name(full_path: &String) -> String {
         .into()
 }
 
+fn is_version_directory(path: &String) -> bool {
+    let re = Regex::new(r"\d+\.\d+\.\d+").unwrap();
+    re.is_match(path)
+}
+
 pub fn current_version() -> Option<String> {
     let home_directory = setup::avm_directory();
     let path = match fs::read_link(Path::new(&home_directory).join("node")) {
@@ -48,7 +53,7 @@ pub fn ls_versions() -> Vec<String> {
     let mut paths = Vec::new();
     for path in fs::read_dir(home).unwrap() {
         let path_str = path.unwrap().path().display().to_string();
-        if is_directory(&path_str) {
+        if is_directory(&path_str) && is_version_directory(&path_str) {
             paths.push(directory_name(&path_str));
         }
     }

--- a/tests/ls_version.sh
+++ b/tests/ls_version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# The ls command is not supposed to print any other directories
+# then version directories
+
+mkdir -p ~/.avm/bin
+
+cargo run ls | grep bin
+
+if [ $? -eq 0 ]
+then
+  echo "ls printed out bin directory"
+  rm -rf ~/.avm/
+  exit 1
+fi
+rm -rf ~/.avm/


### PR DESCRIPTION
PR for #21 

`avm ls` now omits directories which do not have a version as name
