### PR TITLE
add -v cli option to print out the current version

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ pub enum CmdOption {
     Ls,
     Help,
     Uninstall,
+    Version,
     Unknown
 }
 
@@ -19,6 +20,8 @@ pub fn help() {
     logger::stdout(format!("avm ls\n"));
     logger::stdout(format!("Uninstall a version:"));
     logger::stdout(format!("avm uninstall <version>\n"));
+    logger::stdout(format!("Print version number:"));
+    logger::stdout(format!("avm -v\n"));
     logger::stdout(format!("Print this help menu:"));
     logger::stdout(format!("avm help"));
 }
@@ -47,6 +50,9 @@ pub fn process_arguments(args: &Vec<String>) -> Command {
     }
     else if command == "uninstall" {
         Command{option: CmdOption::Uninstall, args: vec!(args[1].clone()) }
+    }
+    else if command == "-v" {
+        Command{option: CmdOption::Version, args: vec!() }
     }
     else {
         Command { option: CmdOption::Unknown, args: vec!() }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,11 @@ fn uninstall(version: String) {
     }
 }
 
+fn print_version() {
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    println!("v{}", VERSION);
+}
+
 fn main() {
     let args: Vec<String> = env::args()
         .skip(1)
@@ -158,6 +163,9 @@ fn main() {
         cli::CmdOption::Uninstall => {
             let version = cmd_args.args.first().unwrap().clone();
             uninstall(version);
+        },
+        cli::CmdOption::Version => {
+            print_version();
         },
         cli::CmdOption::Help => {
             cli::help();


### PR DESCRIPTION
PR for #18 
when running `avm -v`, it prints out the current version defined in `Cargo.toml`
