### PR TITLE
Make globally installed tools callable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,6 @@ function has_git {
 
 function create_folder {
   mkdir -p ~/.avm/
-  mkdir -p ~/.avm/bin
 }
 
 function download_source {
@@ -33,7 +32,7 @@ function cleanup {
   rm -rf /tmp/avm
 }
 
-function compile {
+function compile_avm {
   cd /tmp/avm/
   cargo build --release
   if [ $? -ne 0 ]
@@ -43,7 +42,7 @@ function compile {
     >&2 echo "fatal: exiting"
     exit 1
   fi
-  cp target/release/avm ~/.avm/bin/avm
+  cp target/release/avm ~/.avm/
 }
 
 echo "Installing avm"
@@ -51,8 +50,8 @@ has_rust
 has_git
 create_folder
 download_source
-compile
+compile_avm
 cleanup
 
 echo "Installation finished"
-echo "Add this export 'PATH=~/.avm/bin:~/.avm/:\$PATH' to your bash configuration file"
+echo "Add this 'export PATH=~/.avm/:~/.avm/bin:\$PATH' to your bash configuration file"

--- a/src/ls.rs
+++ b/src/ls.rs
@@ -26,7 +26,7 @@ fn is_version_directory(path: &String) -> bool {
 
 pub fn current_version() -> Option<String> {
     let home_directory = setup::avm_directory();
-    let path = match fs::read_link(Path::new(&home_directory).join("node")) {
+    let path = match fs::read_link(Path::new(&home_directory).join("bin")) {
         Ok(s) => s,
         _ => return None
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,27 +62,25 @@ fn install(version: String) {
 
 fn use_version(version: String) {
     if setup::has_version(&version) {
-        for executable in vec!["node", "npm"] {
-            match symlink::remove_symlink(&executable.to_string()) {
-                Err(err) => {
-                    if err.kind() != std::io::ErrorKind::NotFound {
-                        logger::stderr(format!("Failed to remove symlink {}", executable));
-                        logger::stderr(format!("{:?}", err));
-                        std::process::exit(1)
-                    }
-                },
-                _ => { }
-            };
-
-            match symlink::symlink_to_version(&version, executable.to_string()) {
-                Ok(_) => logger::stdout(format!("Now using {} {}", executable, version)),
-                Err(err) => {
-                    logger::stderr(format!("Failed to set symlink for {}", executable));
+        match symlink::remove_symlink() {
+            Err(err) => {
+                if err.kind() != std::io::ErrorKind::NotFound {
+                    logger::stderr("Failed to remove symlink");
                     logger::stderr(format!("{:?}", err));
                     std::process::exit(1)
                 }
-            };
-        }
+            },
+            _ => { }
+        };
+
+        match symlink::symlink_to_version(&version) {
+            Ok(_) => logger::stdout(format!("Now using node v{}", version)),
+            Err(err) => {
+                logger::stderr("Failed to set symlink");
+                logger::stderr(format!("{:?}", err));
+                std::process::exit(1)
+            }
+        };
     } else {
         logger::stdout(format!("Version {} not installed", version));
         std::process::exit(1)
@@ -110,17 +108,15 @@ fn uninstall(version: String) {
     if setup::has_version(&version) {
 
         if symlink::points_to_version(&version) {
-            for executable in vec!["node", "npm"] {
-                match symlink::remove_symlink(&executable.to_string()) {
-                    Err(err) => {
-                        if err.kind() != std::io::ErrorKind::NotFound {
-                            logger::stderr(format!("Failed to remove symlink {}", executable));
-                            logger::stderr(format!("{:?}", err));
-                            std::process::exit(1)
-                        }
-                    },
-                    _ => { }
-                }
+            match symlink::remove_symlink() {
+                Err(err) => {
+                    if err.kind() != std::io::ErrorKind::NotFound {
+                        logger::stderr("Failed to remove symlink");
+                        logger::stderr(format!("{:?}", err));
+                        std::process::exit(1)
+                    }
+                },
+                _ => { }
             }
         }
 

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -13,23 +13,19 @@ pub fn points_to_version(version: &String) -> bool {
     &current_version == version
 }
 
-pub fn remove_symlink(executable: &String) -> Result<(), Error> {
+pub fn remove_symlink() -> Result<(), Error> {
     use std::fs;
     let symlink_path = Path::new(&setup::avm_directory())
-        .join(executable)
+        .join("bin")
         .as_path().to_str().unwrap().to_string();
     fs::remove_file(symlink_path)
 }
 
-pub fn symlink_to_version(version_str: &String, executable: String) -> Result<(), Error> {
-    let executable_path= Path::new(&setup::avm_directory())
-        .join(version_str)
-        .join("bin")
-        .join(&executable)
-        .as_path().to_str().unwrap().to_string();
-
-    let dest_executable_path = Path::new(&setup::avm_directory())
-        .join(executable)
-        .as_path().to_str().unwrap().to_string();
-    fs::symlink(executable_path, dest_executable_path)
+pub fn symlink_to_version(version_str: &String) -> Result<(), Error> {
+    let avm_directory = setup::avm_directory();
+    let destination_bin_path = Path::new(&avm_directory)
+                                        .join(version_str)
+                                        .join("bin");
+    let bin_directory = Path::new(&avm_directory).join("bin");
+    fs::symlink(destination_bin_path, bin_directory)
 }

--- a/tests/install_version.sh
+++ b/tests/install_version.sh
@@ -3,7 +3,7 @@
 cargo run install 4.1.2
 
 if [ $? -ne 0 ]; then
-  echo "Didn't exit with status code 0"
+  echo "Compilation was not successful"
   rm -rf ~/.avm/
   exit 1
 fi

--- a/tests/uninstall_version.sh
+++ b/tests/uninstall_version.sh
@@ -3,22 +3,14 @@
 cargo run install 0.12.0
 cargo run use 0.12.0
 cargo run uninstall 0.12.0
-result=$(readlink ~/.avm/node)
+result=$(readlink ~/.avm/bin)
 if [ $? -eq 1 ]
 then
-  echo "Symlink node removed"
+  echo "Symlink to bin directory removed"
 else
-  echo "Symlink node still exists"
+  echo "Symlink to bin directory still exists"
+  rm -rf ~/.avm/
   exit 1
 fi
 
-result=$(readlink ~/.avm/npm)
-if [ $? -eq 1 ]
-then
-  rm -rf ~/.avm/
-  echo "Symlink npm removed"
-else
-  rm -rf ~/.avm/
-  echo "Symlink npm still exists"
-  exit 1
-fi
+rm -rf ~/.avm/

--- a/tests/upgrade_npm.sh
+++ b/tests/upgrade_npm.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cargo run install 0.10.36
+cargo run use 0.10.36
+old_npm_version=$(npm -v)
+npm install -g npm
+new_npm_version=$(npm -v)
+
+if [ new_npm_version == old_npm_version ]
+then
+  echo "fatal: did not successfully upgrade npm"
+  rm -rf ~/.avm
+  exit 1
+else
+  echo "Upgraded npm successfully"
+  rm -rf ~/.avm
+fi

--- a/tests/use_version.sh
+++ b/tests/use_version.sh
@@ -9,7 +9,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-result=$(readlink ~/.avm/npm)
+result=$(readlink ~/.avm/bin)
 if [ $? -ne 0 ]
 then
   echo "Link to version 4.1.2 does not exist"


### PR DESCRIPTION
PR for #22 and #20 

Instead of symlinking `node` and `npm` the complete `bin` folder of the currently used version is symlinked. This ensures that commandline tools are also in scope
