### PR TITLE
Take system node into account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "avm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hyper 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_type 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jan Schulte <hello@unexpected-co.de>"]
 [dependencies]
 hyper="0.6.10"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 
-Right now to install multiple versions of node.js there's [nvm](https://github.com/creationix/nvm) available. It does a decent job but there's one disadvantage: It's written in Shell. On the one hand that's nice because it's easy to install on Unix machines, but on the other hand it's not usable on Windows machines and Shell code is not easy to understand. At least for me. 
+Right now to install multiple versions of node.js there's [nvm](https://github.com/creationix/nvm) available. It does a decent job but there's one disadvantage: It's written in Shell. On the one hand that's nice because it's easy to install on Unix machines, but on the other hand it's not usable on Windows machines and Shell code is not easy to understand. At least for me.
 Especially the latter reason is important for me. It is not that easy to find a person who can maintain Shell code and also it's not that easy to figure out where to look when something goes wrong.
 
 Since Rust has become stable this year, I took the opportunity and began to write a replacement for nvm. It's called avm as abbreviation for "All version manager". In the future I want to be able to not only install node.js but also Ruby and Python on my machine in a convenient way. The other advantage is since Rust runs on many platforms, there's also the possibility to run avm on machines without Bash e.g. Windows.
@@ -56,6 +56,11 @@ Please note, that right now avm installs precompiled versions of Node.js. There 
 Use `4.1.2` by default:
 ```bash
 $ avm use 4.1.2
+```
+Use your system node version:
+
+```bash
+$ avm use system
 ```
 
 List all installed versions:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,8 @@ pub fn help() {
     logger::stdout(format!("avm install <version>\n"));
     logger::stdout(format!("Use a version: "));
     logger::stdout(format!("avm use <version>\n"));
+    logger::stdout(format!("Use system version: "));
+    logger::stdout(format!("avm use system\n"));
     logger::stdout(format!("List all installed versions:"));
     logger::stdout(format!("avm ls\n"));
     logger::stdout(format!("Uninstall a version:"));

--- a/src/ls.rs
+++ b/src/ls.rs
@@ -3,6 +3,11 @@ use setup;
 use std::fs;
 use regex::Regex;
 
+pub struct NodeVersion {
+    pub path: String,
+    pub name: String
+}
+
 fn is_directory(path: &String) -> bool {
     match fs::metadata(path) {
         Ok(metadata) => metadata.is_dir(),
@@ -45,17 +50,21 @@ pub fn current_version() -> Option<String> {
     }
 }
 
-pub fn ls_versions() -> Vec<String> {
+pub fn ls_versions() -> Vec<NodeVersion> {
     if !setup::home_directory_existant() {
         return vec!();
     }
     let home = setup::avm_directory();
-    let mut paths = Vec::new();
+    let mut installed_versions = Vec::new();
     for path in fs::read_dir(home).unwrap() {
         let path_str = path.unwrap().path().display().to_string();
         if is_directory(&path_str) && is_version_directory(&path_str) {
-            paths.push(directory_name(&path_str));
+            let version = NodeVersion{
+                name: directory_name(&path_str),
+                path: path_str.clone()
+            };
+            installed_versions.push(version);
         }
     }
-    paths
+    installed_versions
 }

--- a/src/ls.rs
+++ b/src/ls.rs
@@ -2,14 +2,7 @@ use std::path::Path;
 use setup;
 use std::fs;
 use regex::Regex;
-
-#[derive(Default)]
-#[derive(Debug)]
-#[derive(PartialEq)]
-pub struct NodeVersion {
-    pub path: String,
-    pub name: String
-}
+use node_version::NodeVersion;
 
 fn is_directory<P: AsRef<Path>>(path: P) -> bool {
     match fs::metadata(path) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn use_version(version: String) {
     }
     else if version == "system" {
         remove_symlink();
-        match symlink::symlink_to_system_node() {
+        match symlink::symlink_to_system_binary("node".to_string()) {
             Ok(_)       => logger::stdout("using system node"),
             Err(err)    => {
                 if err.kind() == ErrorKind::NotFound {

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,19 +60,22 @@ fn install(version: String) {
     logger::success(format!("Run avm use {} to use it", version));
 }
 
+fn remove_symlink() {
+    match symlink::remove_symlink() {
+        Err(err) => {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                logger::stderr("Failed to remove symlink");
+                logger::stderr(format!("{:?}", err));
+                std::process::exit(1)
+            }
+        },
+        _ => { }
+    };
+}
+
 fn use_version(version: String) {
     if setup::has_version(&version) {
-        match symlink::remove_symlink() {
-            Err(err) => {
-                if err.kind() != std::io::ErrorKind::NotFound {
-                    logger::stderr("Failed to remove symlink");
-                    logger::stderr(format!("{:?}", err));
-                    std::process::exit(1)
-                }
-            },
-            _ => { }
-        };
-
+        remove_symlink();
         match symlink::symlink_to_version(&version) {
             Ok(_) => logger::success(format!("Now using node v{}", version)),
             Err(err) => {
@@ -83,6 +86,7 @@ fn use_version(version: String) {
         };
     }
     else if version == "system" {
+        remove_symlink();
         match symlink::symlink_to_system_node() {
             Ok(_)       => logger::stdout("using system node"),
             Err(err)    => logger::stderr(format!("{:?}", err))

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,12 +113,12 @@ fn list_versions() {
 
     logger::stdout(format!("Listing all installed versions:"));
     logger::stdout(format!("(=>): current version"));
-    for version in ls::ls_versions() {
-        if version == current_version {
-            logger::stdout(format!("=> {}", version));
+    for installed_version in ls::ls_versions() {
+        if installed_version.name == current_version {
+            logger::stdout(format!("=> {}", installed_version.name));
         }
         else {
-            logger::stdout(format!("- {}", version));
+            logger::stdout(format!("- {}", installed_version.name));
         }
     }
     match system_node::version() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ extern crate hyper;
 extern crate regex;
 extern crate os_type;
 use std::env;
+use std::io::ErrorKind;
 
 fn install(version: String) {
     let home_directory = match setup::prepare() {
@@ -89,7 +90,13 @@ fn use_version(version: String) {
         remove_symlink();
         match symlink::symlink_to_system_node() {
             Ok(_)       => logger::stdout("using system node"),
-            Err(err)    => logger::stderr(format!("{:?}", err))
+            Err(err)    => {
+                if err.kind() == ErrorKind::NotFound {
+                    logger::stderr(format!("It appears that there's no node.js preinstalled on this system"));
+                } else {
+                    logger::stderr(format!("{:?}", err));
+                }
+            }
         }
     }
     else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod setup;
 mod downloader;
 mod archive_reader;
 mod ls;
+mod system_node;
 mod logger;
 extern crate hyper;
 extern crate regex;
@@ -90,6 +91,13 @@ fn list_versions() {
     let current_version = match ls::current_version() {
         Some(v) => v,
         None => String::new()
+    };
+
+    match system_node::version() {
+        Ok(version) => {
+            logger::stdout(format!("System: {}", version));
+        },
+        Err(err) => logger::stderr(format!("{}", err))
     };
     logger::stdout(format!("Listing all installed versions:"));
     logger::stdout(format!("(=>): current version"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,17 +117,23 @@ fn list_versions() {
         Err(_) => Default::default()
     };
     let mut installed_versions = ls::ls_versions();
-    installed_versions.push(system_version);
+    installed_versions.push(system_version.clone());
 
     logger::stdout(format!("Listing all installed versions:"));
     logger::stdout(format!("(=>): current version"));
 
     for installed_version in installed_versions {
+        let system_suffix = if installed_version == system_version {
+            String::from("(system)")
+        } else {
+            String::new()
+        };
+
         if installed_version.path == current_version.path {
-            logger::stdout(format!("=> {}", installed_version.name));
+            logger::stdout(format!("=> {} {}", installed_version.name, system_suffix));
         }
         else if installed_version != Default::default() {
-            logger::stdout(format!("- {}", installed_version.name));
+            logger::stdout(format!("- {} {}", installed_version.name, system_suffix));
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,14 @@ fn use_version(version: String) {
                 std::process::exit(1)
             }
         };
-    } else {
+    }
+    else if version == "system" {
+        match symlink::symlink_to_system_node() {
+            Ok(_)       => logger::stdout("using system node"),
+            Err(err)    => logger::stderr(format!("{:?}", err))
+        }
+    }
+    else {
         logger::stderr(format!("Version {} not installed", version));
         std::process::exit(1)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,13 +108,13 @@ fn use_version(version: String) {
 fn list_versions() {
     let current_version = match ls::current_version() {
         Some(v) => v,
-        None => String::new()
+        None => Default::default()
     };
 
     logger::stdout(format!("Listing all installed versions:"));
     logger::stdout(format!("(=>): current version"));
     for installed_version in ls::ls_versions() {
-        if installed_version.name == current_version {
+        if installed_version == current_version {
             logger::stdout(format!("=> {}", installed_version.name));
         }
         else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,24 +112,24 @@ fn list_versions() {
         None => Default::default()
     };
 
+    let system_version = match system_node::version() {
+        Ok(v) => v,
+        Err(_) => Default::default()
+    };
+    let mut installed_versions = ls::ls_versions();
+    installed_versions.push(system_version);
+
     logger::stdout(format!("Listing all installed versions:"));
     logger::stdout(format!("(=>): current version"));
-    for installed_version in ls::ls_versions() {
-        if installed_version == current_version {
+
+    for installed_version in installed_versions {
+        if installed_version.path == current_version.path {
             logger::stdout(format!("=> {}", installed_version.name));
         }
-        else {
+        else if installed_version != Default::default() {
             logger::stdout(format!("- {}", installed_version.name));
         }
     }
-    match system_node::version() {
-        Ok(version) => {
-            logger::stdout(format!("System: {}", version));
-        },
-        Err(_) => {
-            logger::stdout(format!("System: -"))
-        }
-    };
 }
 
 fn uninstall(version: String) {
@@ -164,7 +164,6 @@ fn uninstall(version: String) {
 
 fn print_version() {
     const VERSION: &'static str = env!("CARGO_PKG_VERSION");
-    println!("v{}", VERSION);
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,10 +94,16 @@ fn use_version(version: String) {
             Err(err)    => {
                 if err.kind() == ErrorKind::NotFound {
                     logger::stderr(format!("It appears that there's no node.js preinstalled on this system"));
+                    return;
                 } else {
                     logger::stderr(format!("{:?}", err));
                 }
             }
+        }
+
+        match symlink::symlink_to_system_binary("npm".to_string()) {
+            Ok(_)       => { },
+            Err(err)    => logger::stderr(format!("{:?}", err))
         }
     }
     else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,12 +93,6 @@ fn list_versions() {
         None => String::new()
     };
 
-    match system_node::version() {
-        Ok(version) => {
-            logger::stdout(format!("System: {}", version));
-        },
-        Err(err) => logger::stderr(format!("{}", err))
-    };
     logger::stdout(format!("Listing all installed versions:"));
     logger::stdout(format!("(=>): current version"));
     for version in ls::ls_versions() {
@@ -109,6 +103,14 @@ fn list_versions() {
             logger::stdout(format!("- {}", version));
         }
     }
+    match system_node::version() {
+        Ok(version) => {
+            logger::stdout(format!("System: {}", version));
+        },
+        Err(_) => {
+            logger::stdout(format!("System: -"))
+        }
+    };
 }
 
 fn uninstall(version: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod archive_reader;
 mod ls;
 mod system_node;
 mod logger;
+mod node_version;
 extern crate hyper;
 extern crate regex;
 extern crate os_type;

--- a/src/node_version.rs
+++ b/src/node_version.rs
@@ -1,6 +1,7 @@
 #[derive(Default)]
 #[derive(Debug)]
 #[derive(PartialEq)]
+#[derive(Clone)]
 pub struct NodeVersion {
     pub path: String,
     pub name: String

--- a/src/node_version.rs
+++ b/src/node_version.rs
@@ -1,0 +1,7 @@
+#[derive(Default)]
+#[derive(Debug)]
+#[derive(PartialEq)]
+pub struct NodeVersion {
+    pub path: String,
+    pub name: String
+}

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -19,7 +19,7 @@ pub fn points_to_version(version: &String) -> bool {
         None => return false
     };
 
-    &current_version == version
+    &current_version.name == version
 }
 
 pub fn remove_symlink() -> Result<(), Error> {

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::os::unix::fs;
 use std::io::Error;
 use ls;
+use system_node;
 
 pub fn points_to_version(version: &String) -> bool {
     let current_version = match ls::current_version() {
@@ -29,3 +30,22 @@ pub fn symlink_to_version(version_str: &String) -> Result<(), Error> {
     let bin_directory = Path::new(&avm_directory).join("bin");
     fs::symlink(destination_bin_path, bin_directory)
 }
+
+fn create_dir() {
+    use std::fs;
+    let avm_directory = setup::avm_directory();
+    setup::prepare();
+    let bin_directory = Path::new(&avm_directory).join("bin");
+    fs::create_dir(bin_directory);
+}
+
+pub fn symlink_to_system_node() -> Result<(), Error> {
+    let avm_directory = setup::avm_directory();
+    let bin_directory = Path::new(&avm_directory).join("bin");
+    create_dir();
+
+    let local_node  = bin_directory.join("node");
+    let system_node_path = system_node::system_node_path().unwrap_or_else(|err| String::new());
+    fs::symlink(system_node_path, local_node)
+}
+

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -5,12 +5,15 @@ use std::io::Error;
 use ls;
 use system_node;
 
-fn create_bin_dir() {
+fn create_bin_dir() -> Result<(), Error> {
     use std::fs;
     let avm_directory = setup::avm_directory();
-    setup::prepare();
+    match setup::prepare() {
+        Ok(_) => { },
+        Err(err) => return Err(err)
+    };
     let bin_directory = Path::new(&avm_directory).join("bin");
-    fs::create_dir(bin_directory);
+    fs::create_dir(bin_directory)
 }
 
 pub fn points_to_version(version: &String) -> bool {
@@ -45,7 +48,10 @@ pub fn symlink_to_version(version_str: &String) -> Result<(), Error> {
 pub fn symlink_to_system_binary(binary_name: String) -> Result<(), Error> {
     let avm_directory = setup::avm_directory();
     let bin_directory = Path::new(&avm_directory).join("bin");
-    create_bin_dir();
+    match create_bin_dir() {
+        Ok(_) => { },
+        Err(err) => return Err(err)
+    }
 
     let local_binary = bin_directory.join(&binary_name);
     let system_binary_path = system_node::path_for_binary(binary_name).unwrap_or_else(|_| String::new());

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -31,7 +31,7 @@ pub fn symlink_to_version(version_str: &String) -> Result<(), Error> {
     fs::symlink(destination_bin_path, bin_directory)
 }
 
-fn create_dir() {
+fn create_bin_dir() {
     use std::fs;
     let avm_directory = setup::avm_directory();
     setup::prepare();
@@ -42,7 +42,7 @@ fn create_dir() {
 pub fn symlink_to_system_node() -> Result<(), Error> {
     let avm_directory = setup::avm_directory();
     let bin_directory = Path::new(&avm_directory).join("bin");
-    create_dir();
+    create_bin_dir();
 
     let local_node  = bin_directory.join("node");
     let system_node_path = system_node::system_node_path().unwrap_or_else(|err| String::new());

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -24,10 +24,13 @@ pub fn points_to_version(version: &String) -> bool {
 
 pub fn remove_symlink() -> Result<(), Error> {
     use std::fs;
-    let symlink_path = Path::new(&setup::avm_directory())
-        .join("bin")
-        .as_path().to_str().unwrap().to_string();
-    fs::remove_file(symlink_path)
+    let symlink_path = Path::new(&setup::avm_directory()).join("bin");
+    let remove_file_result = fs::remove_file(&symlink_path);
+    if remove_file_result.is_err() {
+        fs::remove_dir_all(&symlink_path)
+    } else {
+        remove_file_result
+    }
 }
 
 pub fn symlink_to_version(version_str: &String) -> Result<(), Error> {

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -42,13 +42,13 @@ pub fn symlink_to_version(version_str: &String) -> Result<(), Error> {
     fs::symlink(destination_bin_path, bin_directory)
 }
 
-pub fn symlink_to_system_node() -> Result<(), Error> {
+pub fn symlink_to_system_binary(binary_name: String) -> Result<(), Error> {
     let avm_directory = setup::avm_directory();
     let bin_directory = Path::new(&avm_directory).join("bin");
     create_bin_dir();
 
-    let local_node  = bin_directory.join("node");
-    let system_node_path = system_node::system_node_path().unwrap_or_else(|err| String::new());
-    fs::symlink(system_node_path, local_node)
+    let local_binary = bin_directory.join(&binary_name);
+    let system_binary_path = system_node::path_for_binary(binary_name).unwrap_or_else(|_| String::new());
+    fs::symlink(system_binary_path, local_binary)
 }
 

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -5,6 +5,14 @@ use std::io::Error;
 use ls;
 use system_node;
 
+fn create_bin_dir() {
+    use std::fs;
+    let avm_directory = setup::avm_directory();
+    setup::prepare();
+    let bin_directory = Path::new(&avm_directory).join("bin");
+    fs::create_dir(bin_directory);
+}
+
 pub fn points_to_version(version: &String) -> bool {
     let current_version = match ls::current_version() {
         Some(v) => v,
@@ -29,14 +37,6 @@ pub fn symlink_to_version(version_str: &String) -> Result<(), Error> {
                                         .join("bin");
     let bin_directory = Path::new(&avm_directory).join("bin");
     fs::symlink(destination_bin_path, bin_directory)
-}
-
-fn create_bin_dir() {
-    use std::fs;
-    let avm_directory = setup::avm_directory();
-    setup::prepare();
-    let bin_directory = Path::new(&avm_directory).join("bin");
-    fs::create_dir(bin_directory);
 }
 
 pub fn symlink_to_system_node() -> Result<(), Error> {

--- a/src/system_node.rs
+++ b/src/system_node.rs
@@ -5,7 +5,7 @@ use node_version::NodeVersion;
 
 fn paths_without_avm() -> Vec<String> {
     let path_env = read_env().unwrap();
-    remove_avm_paths(split_path(&path_env))
+    strip_avm_paths(split_path(&path_env))
 }
 
 
@@ -22,7 +22,7 @@ fn split_path(path: &String) -> Vec<String> {
         .collect::<Vec<_>>()
 }
 
-fn remove_avm_paths(all_paths: Vec<String>) -> Vec<String> {
+fn strip_avm_paths(all_paths: Vec<String>) -> Vec<String> {
     all_paths.iter()
         .filter(|p| !p.contains(".avm"))
         .map(|p| p.to_string())

--- a/src/system_node.rs
+++ b/src/system_node.rs
@@ -35,7 +35,12 @@ fn call_system_node(paths_without_avm: Vec<String>) -> Result<String, Error> {
         .env("PATH", env::join_paths(paths_without_avm).unwrap())
         .output();
     match output {
-        Ok(r) => Ok(String::from_utf8_lossy(&r.stdout).to_string()),
+        Ok(r) => {
+            let version = String::from_utf8_lossy(&r.stdout)
+                .replace("v", "")
+                .to_string();
+            Ok(version)
+        },
         Err(err) => return Err(err)
     }
 }

--- a/src/system_node.rs
+++ b/src/system_node.rs
@@ -1,0 +1,44 @@
+use std::env;
+use std::io::Error;
+use std::process::Command;
+
+fn read_env() -> Option<String> {
+    match env::var("PATH") {
+        Ok(val) => Some(val),
+        Err(_)  => None
+    }
+}
+
+fn split_path(path: &String) -> Vec<String> {
+    env::split_paths(path)
+        .map(|p| String::from(p.to_str().unwrap()))
+        .collect::<Vec<_>>()
+}
+
+fn remove_avm_paths(all_paths: Vec<String>) -> Vec<String> {
+    all_paths.iter()
+        .filter(|p| !p.contains(".avm"))
+        .map(|p| p.to_string())
+        .collect::<Vec<_>>()
+}
+
+fn set_new_path_variable(paths: Vec<String>) {
+    let new_path = env::join_paths(paths).unwrap();
+    env::set_var("PATH", &new_path);
+}
+
+fn call_system_node() -> Result<String, Error> {
+    let output = match Command::new("node").arg("-v").output() {
+        Ok(r) => r,
+        Err(err) => return Err(err)
+    };
+    let foo = String::from_utf8_lossy(&output.stdout);
+    Ok(foo.to_string())
+}
+
+pub fn version() -> Result<String, Error> {
+    let path_env = read_env().unwrap();
+    let paths_without_avm = remove_avm_paths(split_path(&path_env));
+    set_new_path_variable(paths_without_avm);
+    call_system_node()
+}

--- a/src/system_node.rs
+++ b/src/system_node.rs
@@ -22,23 +22,20 @@ fn remove_avm_paths(all_paths: Vec<String>) -> Vec<String> {
         .collect::<Vec<_>>()
 }
 
-fn set_new_path_variable(paths: Vec<String>) {
-    let new_path = env::join_paths(paths).unwrap();
-    env::set_var("PATH", &new_path);
-}
-
-fn call_system_node() -> Result<String, Error> {
-    let output = match Command::new("node").arg("-v").output() {
+fn call_system_node(paths_without_avm: Vec<String>) -> Result<String, Error> {
+    let output = Command::new("node")
+        .arg("-v")
+        .env("PATH", env::join_paths(paths_without_avm).unwrap())
+        .output();
+    let output_result = match output {
         Ok(r) => r,
         Err(err) => return Err(err)
     };
-    let foo = String::from_utf8_lossy(&output.stdout);
-    Ok(foo.to_string())
+    Ok(String::from_utf8_lossy(&output_result.stdout).to_string())
 }
 
 pub fn version() -> Result<String, Error> {
     let path_env = read_env().unwrap();
     let paths_without_avm = remove_avm_paths(split_path(&path_env));
-    set_new_path_variable(paths_without_avm);
-    call_system_node()
+    call_system_node(paths_without_avm)
 }

--- a/src/system_node.rs
+++ b/src/system_node.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::io::Error;
 use std::process::Command;
+use node_version::NodeVersion;
 
 fn paths_without_avm() -> Vec<String> {
     let path_env = read_env().unwrap();
@@ -59,6 +60,18 @@ pub fn system_node_path() -> Result<String, Error> {
     }
 }
 
-pub fn version() -> Result<String, Error> {
-    call_system_node(paths_without_avm())
+pub fn version() -> Result<NodeVersion, Error> {
+    let node_version = call_system_node(paths_without_avm());
+    let node_path = system_node_path();
+
+    if node_version.is_ok() && node_path.is_ok() {
+        Ok(NodeVersion {
+            path: node_path.unwrap(),
+            name: node_version.unwrap()
+        })
+    } else if node_version.is_err() {
+        Err(node_version.err().unwrap())
+    } else {
+        Err(node_path.err().unwrap())
+    }
 }

--- a/src/system_node.rs
+++ b/src/system_node.rs
@@ -39,6 +39,7 @@ fn call_system_node(paths_without_avm: Vec<String>) -> Result<String, Error> {
         Ok(r) => {
             let version = String::from_utf8_lossy(&r.stdout)
                 .replace("v", "")
+                .replace("\n", "")
                 .to_string();
             Ok(version)
         },

--- a/src/system_node.rs
+++ b/src/system_node.rs
@@ -2,6 +2,12 @@ use std::env;
 use std::io::Error;
 use std::process::Command;
 
+fn paths_without_avm() -> Vec<String> {
+    let path_env = read_env().unwrap();
+    remove_avm_paths(split_path(&path_env))
+}
+
+
 fn read_env() -> Option<String> {
     match env::var("PATH") {
         Ok(val) => Some(val),
@@ -22,6 +28,7 @@ fn remove_avm_paths(all_paths: Vec<String>) -> Vec<String> {
         .collect::<Vec<_>>()
 }
 
+
 fn call_system_node(paths_without_avm: Vec<String>) -> Result<String, Error> {
     let output = Command::new("node")
         .arg("-v")
@@ -33,8 +40,20 @@ fn call_system_node(paths_without_avm: Vec<String>) -> Result<String, Error> {
     }
 }
 
+pub fn system_node_path() -> Result<String, Error> {
+    let output = Command::new("which")
+        .arg("node")
+        .env("PATH", env::join_paths(paths_without_avm()).unwrap())
+        .output();
+    match output {
+        Ok(r) => {
+            let shellout = String::from_utf8_lossy(&r.stdout);
+            Ok(shellout.replace("\n", "").to_string())
+        }
+        Err(err) => return Err(err)
+    }
+}
+
 pub fn version() -> Result<String, Error> {
-    let path_env = read_env().unwrap();
-    let paths_without_avm = remove_avm_paths(split_path(&path_env));
-    call_system_node(paths_without_avm)
+    call_system_node(paths_without_avm())
 }

--- a/src/system_node.rs
+++ b/src/system_node.rs
@@ -47,9 +47,9 @@ fn call_system_node(paths_without_avm: Vec<String>) -> Result<String, Error> {
     }
 }
 
-pub fn system_node_path() -> Result<String, Error> {
+pub fn path_for_binary(binary: String) -> Result<String, Error> {
     let output = Command::new("which")
-        .arg("node")
+        .arg(binary)
         .env("PATH", env::join_paths(paths_without_avm()).unwrap())
         .output();
     match output {
@@ -63,7 +63,7 @@ pub fn system_node_path() -> Result<String, Error> {
 
 pub fn version() -> Result<NodeVersion, Error> {
     let node_version = call_system_node(paths_without_avm());
-    let node_path = system_node_path();
+    let node_path = path_for_binary("node".to_string());
 
     if node_version.is_ok() && node_path.is_ok() {
         Ok(NodeVersion {

--- a/src/system_node.rs
+++ b/src/system_node.rs
@@ -27,11 +27,10 @@ fn call_system_node(paths_without_avm: Vec<String>) -> Result<String, Error> {
         .arg("-v")
         .env("PATH", env::join_paths(paths_without_avm).unwrap())
         .output();
-    let output_result = match output {
-        Ok(r) => r,
+    match output {
+        Ok(r) => Ok(String::from_utf8_lossy(&r.stdout).to_string()),
         Err(err) => return Err(err)
-    };
-    Ok(String::from_utf8_lossy(&output_result.stdout).to_string())
+    }
 }
 
 pub fn version() -> Result<String, Error> {


### PR DESCRIPTION
PR for #27 
- [x] symlink system node.js
- [x] symlink system npm
- [x] handle the case when system node is not installed
- [x] Change output `avm ls` when using system node

This enables the user to also use the system's version of node.js if wanted by running:

``` bash
$ avm use system
```

This creates a `~/.avm/bin` directory and symlinks `node` and `npm` into it. This works only if the system has node.js preinstalled somewhere. If not, it aborts with an error.

`avm ls` also lists the system node version:

``` bash
$ avm ls
Listing all installed versions:
(=>): current version
- 4.1.2
=> 5.0.0
- 0.10.25 (system)
```
