### PR TITLE
Filter AlreadyExists error when creating bin directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "avm"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "hyper 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_type 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jan Schulte <hello@unexpected-co.de>"]
 [dependencies]
 hyper="0.6.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn use_version(version: String) {
     }
     else if version == "system" {
         remove_symlink();
-        match symlink::symlink_to_system_binary("node".to_string()) {
+        match symlink::create_symlinks_to_system_binaries() {
             Ok(_)       => logger::stdout("using system node"),
             Err(err)    => {
                 if err.kind() == ErrorKind::NotFound {
@@ -99,11 +99,6 @@ fn use_version(version: String) {
                     logger::stderr(format!("{:?}", err));
                 }
             }
-        }
-
-        match symlink::symlink_to_system_binary("npm".to_string()) {
-            Ok(_)       => { },
-            Err(err)    => logger::stderr(format!("{:?}", err))
         }
     }
     else {

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -1,7 +1,7 @@
 use setup;
 use std::path::Path;
 use std::os::unix::fs;
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 use ls;
 use system_node;
 
@@ -50,7 +50,11 @@ pub fn symlink_to_system_binary(binary_name: String) -> Result<(), Error> {
     let bin_directory = Path::new(&avm_directory).join("bin");
     match create_bin_dir() {
         Ok(_) => { },
-        Err(err) => return Err(err)
+        Err(err) => {
+            if err.kind() != ErrorKind::AlreadyExists {
+                return Err(err)
+            }
+        }
     }
 
     let local_binary = bin_directory.join(&binary_name);


### PR DESCRIPTION
When running `avm use system` on Mac OS X it raises `AlreadyExists` errors because it tries to create the bin directory twice. Strangely this does not occur on Linux.
This PR fixes that odd behavior.
