### PR TITLE
use https clone url

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ function create_folder {
 }
 
 function download_source {
-  git clone git@github.com:schultyy/avm.git /tmp/avm
+  gith clone https://github.com/schultyy/avm.git /tmp/avm
 }
 
 function cleanup {


### PR DESCRIPTION
PR for #56 

The installer uses https to clone the project. This avoids errors when a user doesn't have ssh access configured for their GitHub account
