### PR TITLE
Do not print system node if when it is not installed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,9 @@ fn list_versions() {
         Err(_) => Default::default()
     };
     let mut installed_versions = ls::ls_versions();
-    installed_versions.push(system_version.clone());
+    if system_version != Default::default() {
+        installed_versions.push(system_version.clone());
+    }
 
     logger::stdout(format!("Listing all installed versions:"));
     logger::stdout(format!("(=>): current version"));

--- a/tests/ls_without_installed_versions.sh
+++ b/tests/ls_without_installed_versions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# The ls command is not supposed to print the following when there's
+# nothing installed
+#
+# Listing all installed versions:
+# (=>): current version
+# =>  (system)
+
+cargo run ls | grep "=>  (system)"
+
+if [ $? -eq 0 ]
+then
+  echo "Printed system node version even it doesn't exist"
+  exit 1
+fi


### PR DESCRIPTION
Given the case there's no node installed yet, avm prints:

``` bash
$ avm ls
Listing all installed versions:
(=>): current version
=>  (system)
```

Instead it prints now

``` bash
$ avm ls
Listing all installed versions:
(=>): current version
```
