### PR TITLE
Build ruby with readline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ curl https://raw.githubusercontent.com/schultyy/avm/master/install.sh | bash
 
 If Rust is not installed yet, visit [https://www.rust-lang.org/downloads.html](https://www.rust-lang.org/downloads.html) and download the version for your operating system.
 
+### Required Packages
+
+- zlib development packages (`zlib1g-dev`)
+- readline support (`libreadline6` `libreadline6-dev`)
+
+### Troubleshooting
 
 If you encounter the following compilation error on a Linux based system:
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ If Rust is not installed yet, visit [https://www.rust-lang.org/downloads.html](h
 
 ### Required Packages
 
-- zlib development packages (`zlib1g-dev`)
-- readline support (`libreadline6` `libreadline6-dev`)
+- zlib development packages (Ubuntu: `zlib1g-dev`)
+- readline support (Ubuntu: `libreadline6` `libreadline6-dev`)
+- C Compiler (Ubuntu: `build-essential`)
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -41,28 +41,9 @@ If Rust is not installed yet, visit [https://www.rust-lang.org/downloads.html](h
 - zlib development packages (Ubuntu: `zlib1g-dev`)
 - readline support (Ubuntu: `libreadline6` `libreadline6-dev`)
 - C Compiler (Ubuntu: `build-essential`)
+- OpenSSL (Ubuntu: `libssl-dev`, RHEL: `openssl-dev`, Mac: `openssl`)
 
-### Troubleshooting
-
-If you encounter the following compilation error on a Linux based system:
-
-```bash
-$ cargo build
-#...
-failed to run custom build command for `openssl-sys v0.6.6`
-```
-
-make sure that you have the following package installed:
-Ubuntu:
-```bash
-$ sudo apt-get install libssl-dev
-```
-RHEL:
-```bash
-$ sudo yum install openssl-devel
-```
-
-Mac:
+OpenSSL Mac:
 ```bash
 export OPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2e/include
 ```

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -98,6 +98,7 @@ pub mod ruby {
         }
 
         logger::success(format!("Successfully installed Ruby {}", &version));
+        logger::success(format!("Run avm use  ruby {} to use it", version));
     }
 
     pub fn remove_symlink() {
@@ -253,7 +254,7 @@ pub mod node {
         };
 
         logger::success(format!("Successfully installed version {}", version));
-        logger::success(format!("Run avm use {} to use it", version));
+        logger::success(format!("Run avm use  node {} to use it", version));
     }
 
     pub fn remove_symlink() {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -16,6 +16,7 @@ impl Compiler {
         Command::new("./configure")
             .arg(format!("--prefix={}", prefix_path))
             .current_dir(Path::new(&self.working_dir))
+            .env("RUBY_CONFIGURE_OPTS","--with-readline-dir=\"/usr/lib\"")
             .output()
             .expect("Failed to call Configure script")
     }


### PR DESCRIPTION
PR for #80 

This adds the missing parameter for the Configure script to compile Ruby with Readline support.
The docs got a minor update with a list of required packages which need to be installed 
