### PR TITLE
Configurable openssl path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,17 @@ curl https://raw.githubusercontent.com/schultyy/avm/master/install.sh | bash
 
 If Rust is not installed yet, visit [https://www.rust-lang.org/downloads.html](https://www.rust-lang.org/downloads.html) and download the version for your operating system.
 
-### Required Packages
+### Required Packages for installing Ruby
 
 - zlib development packages (Ubuntu: `zlib1g-dev`)
 - readline support (Ubuntu: `libreadline6` `libreadline6-dev`)
 - C Compiler (Ubuntu: `build-essential`)
 - OpenSSL (Ubuntu: `libssl-dev`, RHEL: `openssl-dev`, Mac: `openssl`)
 
-OpenSSL Mac:
+By default, avm uses `/usr/include/openssl` as a lookup path. If you want to use a custom path, for example to link against an OpenSSL version installed via homebrew, export `OPENSSL_INCLUDE_DIR`:
+
 ```bash
-export OPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2e/include
+export OPENSSL_INCLUDE_DIR="$(brew --prefix openssl)"
 ```
 
 ### After installation

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -16,7 +16,7 @@ impl Compiler {
     fn openssl_path(&self) -> String {
         match env::var("OPENSSL_INCLUDE_DIR") {
             Ok(val) => val,
-            Err(_) => "/usr/bin".into()
+            Err(_) => "/usr/include/openssl".into()
         }
     }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,5 +1,6 @@
 use std::process::{Command, Output};
 use std::path::Path;
+use std::env;
 
 pub struct Compiler {
     working_dir: String
@@ -12,9 +13,17 @@ impl Compiler {
         }
     }
 
+    fn openssl_path(&self) -> String {
+        match env::var("OPENSSL_INCLUDE_DIR") {
+            Ok(val) => val,
+            Err(_) => "/usr/bin".into()
+        }
+    }
+
     pub fn call_configure_script(&self, prefix_path: &str) -> Output {
         Command::new("./configure")
             .arg(format!("--prefix={}", prefix_path))
+            .arg(format!("--with-openssl-dir={}", self.openssl_path()))
             .current_dir(Path::new(&self.working_dir))
             .env("RUBY_CONFIGURE_OPTS","--with-readline-dir=\"/usr/lib\"")
             .output()


### PR DESCRIPTION
PR for #82 

avm by default passes `--with-openssl-dir` to `Configure`. By default it looks in `/usr/include/openssl` but the user can override this by defining the `OPENSSL_INCLUDE_DIR` environment variable.
